### PR TITLE
fix: Gemini requires Array types to provide schemas

### DIFF
--- a/src/lib/tools/workflow-steps.ts
+++ b/src/lib/tools/workflow-steps.ts
@@ -77,6 +77,58 @@ const SHARED_PROMPTS = {
   `,
 };
 
+const contentTypes = z.enum([
+  "markdown",
+  "html",
+  "image",
+  "button_set",
+  "divider",
+  "partial",
+]);
+
+const contentBlockSchema = z.union([
+  z
+    .object({
+      type: contentTypes,
+      content: z.string(),
+    })
+    .describe("A block of markdown content."),
+  z
+    .object({
+      type: contentTypes,
+      content: z.string(),
+    })
+    .describe("A block of HTML content."),
+  z
+    .object({
+      type: contentTypes,
+      url: z.string(),
+    })
+    .describe("A block that supports an image."),
+  z
+    .object({
+      type: contentTypes,
+      buttons: z.array(
+        z.object({
+          label: z.string(),
+          action: z.string(),
+          variant: z.string(),
+        })
+      ),
+    })
+    .describe("A block that adds one or more buttons."),
+  z
+    .object({
+      type: contentTypes,
+    })
+    .describe("A block that adds a divider."),
+  z.object({
+    type: contentTypes,
+    key: z.string(),
+    attrs: z.array(z.string()).optional(),
+  }),
+]);
+
 const createEmailStepInWorkflow = KnockTool({
   method: "create_email_step_in_workflow",
   name: "Create email step in workflow",
@@ -184,7 +236,7 @@ const createEmailStepInWorkflow = KnockTool({
       .string()
       .describe("(string): The key of the workflow to add the step to."),
     blocks: z
-      .array(z.any())
+      .array(contentBlockSchema)
       .describe("(array): The blocks for the email step."),
     subject: z.string().describe("(string): The subject of the email step."),
   }),


### PR DESCRIPTION
We saw this error in Cursor
![CleanShot 2025-05-14 at 19 51 05@2x](https://github.com/user-attachments/assets/e84b8cb6-4b6d-4d4c-b92e-02a74b5d3964)

And I saw this error in Zed:

```
Error interacting with language model
failed to stream completion
error during streamGenerateContent, status code: 400, body: {
  "error": {
    "code": 400,
    "message": "* GenerateContentRequest.tools[0].function_declarations[21].parameters.properties[blocks].items: missing field.\n",
    "status": "INVALID_ARGUMENT"
  }
}
```
If you combine the zed error message with the cursor error message  you see that there's a problem with the `blocks` parameter of the `create_sms_step_in_workflow` tool

After a bit of digging I found that Gemini has a history of being quite picky with the subset of OpenAPI that it supports. 


# References
- https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#function_declarations
- https://ai.google.dev/api/caching#Schema