### PR TITLE
chore: make htmlContent and blocks optional for email templates

### DIFF
--- a/src/lib/tools/workflow-steps.ts
+++ b/src/lib/tools/workflow-steps.ts
@@ -252,11 +252,13 @@ const createOrUpdateEmailStepInWorkflow = KnockTool({
       ),
     htmlContent: z
       .string()
+      .optional()
       .describe(
         "(string): The HTML content of the email template. Use this when not setting blocks."
       ),
     blocks: z
       .array(contentBlockSchema)
+      .optional()
       .describe(
         "(array): The blocks for the email step. Use this when you don't need to set HTML directly."
       ),


### PR DESCRIPTION
### Description

This PR makes `htmlContent` and `blocks` under `createOrUpdateEmailStepInWorkflow` optional, as we should only ever provide one or the other. 