### PR TITLE
fix: ensure email steps work correctly between html and blocks

### DIFF
--- a/.changeset/chubby-dolls-take.md
+++ b/.changeset/chubby-dolls-take.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/agent-toolkit": patch
+---
+
+fix: issue with create or update email tool and html templates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knocklabs/agent-toolkit",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knocklabs/agent-toolkit",
-      "version": "0.5.2",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@knocklabs/mgmt": "^0.2.0",

--- a/src/lib/tools/__tests__/workflow-steps.test.ts
+++ b/src/lib/tools/__tests__/workflow-steps.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { KnockClient } from "../../knock-client.js";
+import { workflowStepTools } from "../workflow-steps.js";
+
+const mockWorkflow = {
+  key: "wf-1",
+  name: "WF",
+  steps: [] as unknown[],
+  description: "",
+  active: true,
+  created_at: "",
+};
+
+describe("createOrUpdateEmailStepInWorkflow", () => {
+  const config = { serviceToken: "test" };
+
+  let upsertMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    upsertMock = vi.fn().mockResolvedValue({
+      workflow: mockWorkflow,
+    });
+  });
+
+  function makeClient(): KnockClient {
+    return {
+      workflows: {
+        retrieve: vi.fn().mockResolvedValue(mockWorkflow),
+        upsert: upsertMock,
+      },
+      channels: {
+        list: vi.fn().mockResolvedValue({
+          entries: [{ key: "email-1", type: "email" }],
+        }),
+      },
+    } as unknown as KnockClient;
+  }
+
+  function getUpsertedEmailTemplate() {
+    const [, params] = upsertMock.mock.calls[0] as [
+      string,
+      { workflow: { steps: { template: Record<string, unknown> }[] } },
+    ];
+    const steps = params.workflow.steps;
+    return steps[steps.length - 1].template;
+  }
+
+  it("includes only html_content when htmlContent is set with blocks: []", async () => {
+    const run =
+      workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
+        makeClient(),
+        config
+      );
+
+    await run({
+      workflowKey: "wf-1",
+      layoutKey: "default",
+      subject: "Hi",
+      htmlContent: "<p>x</p>",
+      blocks: [],
+    });
+
+    const template = getUpsertedEmailTemplate();
+    expect(template).toHaveProperty("html_content", "<p>x</p>");
+    expect(template).not.toHaveProperty("visual_blocks");
+  });
+
+  it("includes only visual_blocks when using blocks without htmlContent", async () => {
+    const run =
+      workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
+        makeClient(),
+        config
+      );
+
+    await run({
+      workflowKey: "wf-1",
+      layoutKey: "default",
+      subject: "Hi",
+      blocks: [{ type: "markdown", content: "Hello" }],
+    });
+
+    const template = getUpsertedEmailTemplate();
+    expect(template).toHaveProperty("visual_blocks");
+    expect(template).not.toHaveProperty("html_content");
+  });
+
+  it("rejects non-empty htmlContent and blocks together", async () => {
+    const run =
+      workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
+        makeClient(),
+        config
+      );
+
+    const res = await run({
+      workflowKey: "wf-1",
+      layoutKey: "default",
+      subject: "Hi",
+      htmlContent: "<p>x</p>",
+      blocks: [{ type: "markdown", content: "y" }],
+    });
+    expect(res).toMatchObject({
+      message: expect.stringMatching(/not both/i),
+    });
+  });
+
+  it("rejects when neither htmlContent nor blocks are provided", async () => {
+    const run =
+      workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
+        makeClient(),
+        config
+      );
+
+    const res = await run({
+      workflowKey: "wf-1",
+      layoutKey: "default",
+      subject: "Hi",
+    });
+    expect(res).toMatchObject({
+      message: expect.stringMatching(/either htmlContent/i),
+    });
+  });
+
+});

--- a/src/lib/tools/__tests__/workflow-steps.test.ts
+++ b/src/lib/tools/__tests__/workflow-steps.test.ts
@@ -47,11 +47,10 @@ describe("createOrUpdateEmailStepInWorkflow", () => {
   }
 
   it("includes only html_content when htmlContent is set with blocks: []", async () => {
-    const run =
-      workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
-        makeClient(),
-        config
-      );
+    const run = workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
+      makeClient(),
+      config
+    );
 
     await run({
       workflowKey: "wf-1",
@@ -67,11 +66,10 @@ describe("createOrUpdateEmailStepInWorkflow", () => {
   });
 
   it("includes only visual_blocks when using blocks without htmlContent", async () => {
-    const run =
-      workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
-        makeClient(),
-        config
-      );
+    const run = workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
+      makeClient(),
+      config
+    );
 
     await run({
       workflowKey: "wf-1",
@@ -86,11 +84,10 @@ describe("createOrUpdateEmailStepInWorkflow", () => {
   });
 
   it("rejects non-empty htmlContent and blocks together", async () => {
-    const run =
-      workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
-        makeClient(),
-        config
-      );
+    const run = workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
+      makeClient(),
+      config
+    );
 
     const res = await run({
       workflowKey: "wf-1",
@@ -105,11 +102,10 @@ describe("createOrUpdateEmailStepInWorkflow", () => {
   });
 
   it("rejects when neither htmlContent nor blocks are provided", async () => {
-    const run =
-      workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
-        makeClient(),
-        config
-      );
+    const run = workflowStepTools.createOrUpdateEmailStepInWorkflow.bindExecute(
+      makeClient(),
+      config
+    );
 
     const res = await run({
       workflowKey: "wf-1",
@@ -120,5 +116,4 @@ describe("createOrUpdateEmailStepInWorkflow", () => {
       message: expect.stringMatching(/either htmlContent/i),
     });
   });
-
 });

--- a/src/lib/tools/workflow-serialize.ts
+++ b/src/lib/tools/workflow-serialize.ts
@@ -1,0 +1,37 @@
+import { Workflow, WorkflowStep } from "@knocklabs/mgmt/resources/index.js";
+
+/**
+ * A slimmed down version of the Workflow resource that is easier to work with in the LLM.
+ */
+export type SerializedWorkflow = {
+  key: string;
+  name: string;
+  description: string | undefined;
+  categories: string[] | undefined;
+  schema: Record<string, unknown> | undefined;
+};
+
+export function serializeWorkflowResponse(
+  workflow: Workflow
+): SerializedWorkflow {
+  return {
+    key: workflow.key,
+    name: workflow.name,
+    description: workflow.description,
+    categories: workflow.categories,
+    schema: workflow.trigger_data_json_schema,
+  };
+}
+
+export function serializeFullWorkflowResponse(
+  workflow: Workflow
+): SerializedWorkflow & { steps: WorkflowStep[] } {
+  return {
+    key: workflow.key,
+    name: workflow.name,
+    description: workflow.description,
+    categories: workflow.categories,
+    schema: workflow.trigger_data_json_schema,
+    steps: workflow.steps,
+  };
+}

--- a/src/lib/tools/workflow-steps.ts
+++ b/src/lib/tools/workflow-steps.ts
@@ -13,7 +13,7 @@ import { z } from "zod";
 import { KnockClient } from "../knock-client.js";
 import { KnockTool } from "../knock-tool.js";
 
-import { serializeWorkflowResponse } from "./workflows";
+import { serializeWorkflowResponse } from "./workflow-serialize.js";
 
 function generateStepRef(stepType: string) {
   const randomString = Math.random().toString(36).substring(2, 7).toUpperCase();
@@ -135,6 +135,40 @@ const contentBlockSchema = z.union([
       ),
   }),
 ]);
+
+type ContentBlock = z.infer<typeof contentBlockSchema>;
+
+function validateEmailStepContent(params: {
+  htmlContent?: string | undefined;
+  blocks?: ContentBlock[] | undefined;
+}):
+  | { ok: true; kind: "html"; html: string }
+  | { ok: true; kind: "blocks"; blocks: ContentBlock[] }
+  | { ok: false; message: string } {
+  const trimmedHtml = params.htmlContent?.trim() ?? "";
+  const hasHtml = trimmedHtml.length > 0;
+  const hasBlocks = params.blocks !== undefined;
+
+  if (!hasHtml && !hasBlocks) {
+    return {
+      ok: false,
+      message: "Provide either htmlContent (non-empty) or blocks.",
+    };
+  }
+
+  if (hasHtml && hasBlocks && (params.blocks?.length ?? 0) > 0) {
+    return {
+      ok: false,
+      message: "Provide either htmlContent or blocks, not both.",
+    };
+  }
+
+  if (hasHtml) {
+    return { ok: true, kind: "html", html: trimmedHtml };
+  }
+
+  return { ok: true, kind: "blocks", blocks: params.blocks! };
+}
 
 const createOrUpdateEmailStepInWorkflow = KnockTool({
   method: "upsert_workflow_email_step",
@@ -296,6 +330,24 @@ const createOrUpdateEmailStepInWorkflow = KnockTool({
       throw new Error("No email channels found");
     }
 
+    const content = validateEmailStepContent(params);
+    if (!content.ok) {
+      throw new Error(content.message);
+    }
+
+    const templateBase = {
+      settings: {
+        layout_key: params.layoutKey ?? "default",
+      },
+      subject: params.subject,
+    };
+
+    const template = (
+      content.kind === "html"
+        ? { ...templateBase, html_content: content.html }
+        : { ...templateBase, visual_blocks: content.blocks }
+    ) as EmailTemplate;
+
     return await updateWorkflowWithStep(
       knockClient,
       workflow,
@@ -303,14 +355,7 @@ const createOrUpdateEmailStepInWorkflow = KnockTool({
       {
         type: "channel",
         channel_key: params.channelKey ?? emailChannels[0].key,
-        template: {
-          settings: {
-            layout_key: params.layoutKey ?? "default",
-          },
-          subject: params.subject,
-          visual_blocks: params.blocks,
-          html_content: params.htmlContent,
-        } as EmailTemplate,
+        template,
         ref: params.stepRef ?? generateStepRef("email"),
       },
       environment

--- a/src/lib/tools/workflows.ts
+++ b/src/lib/tools/workflows.ts
@@ -1,45 +1,17 @@
-import { Workflow, WorkflowStep } from "@knocklabs/mgmt/resources/index.js";
+import { Workflow } from "@knocklabs/mgmt/resources/index.js";
 import { z } from "zod";
 
 import { KnockTool } from "../knock-tool.js";
 
 import { workflowStepTools } from "./workflow-steps.js";
+import {
+  serializeFullWorkflowResponse,
+  serializeWorkflowResponse,
+  type SerializedWorkflow,
+} from "./workflow-serialize.js";
 
-/**
- * A slimmed down version of the Workflow resource that is easier to work with in the LLM.
- */
-export type SerializedWorkflow = {
-  key: string;
-  name: string;
-  description: string | undefined;
-  categories: string[] | undefined;
-  schema: Record<string, unknown> | undefined;
-};
-
-export function serializeWorkflowResponse(
-  workflow: Workflow
-): SerializedWorkflow {
-  return {
-    key: workflow.key,
-    name: workflow.name,
-    description: workflow.description,
-    categories: workflow.categories,
-    schema: workflow.trigger_data_json_schema,
-  };
-}
-
-export function serializeFullWorkflowResponse(
-  workflow: Workflow
-): SerializedWorkflow & { steps: WorkflowStep[] } {
-  return {
-    key: workflow.key,
-    name: workflow.name,
-    description: workflow.description,
-    categories: workflow.categories,
-    schema: workflow.trigger_data_json_schema,
-    steps: workflow.steps,
-  };
-}
+export type { SerializedWorkflow };
+export { serializeFullWorkflowResponse, serializeWorkflowResponse };
 
 const listWorkflows = KnockTool({
   method: "list_workflows",

--- a/src/lib/tools/workflows.ts
+++ b/src/lib/tools/workflows.ts
@@ -1,14 +1,13 @@
-import { Workflow } from "@knocklabs/mgmt/resources/index.js";
 import { z } from "zod";
 
 import { KnockTool } from "../knock-tool.js";
 
-import { workflowStepTools } from "./workflow-steps.js";
 import {
   serializeFullWorkflowResponse,
   serializeWorkflowResponse,
   type SerializedWorkflow,
 } from "./workflow-serialize.js";
+import { workflowStepTools } from "./workflow-steps.js";
 
 export type { SerializedWorkflow };
 export { serializeFullWorkflowResponse, serializeWorkflowResponse };


### PR DESCRIPTION
**Problem**: The “create or update email step in workflow” tool always sent both html_content and visual_blocks on the email template. The Knock API only allows one of those, so calls that mixed HTML with an empty or present blocks array often returned 422 (“must have exactly one of: html_body, visual_blocks”).

**What we did**: We now pick a single content mode before calling the API: non-empty HTML uses only html_content; block-based content uses only visual_blocks. We validate in the tool handler so missing content or conflicting non-empty HTML plus non-empty blocks fail fast with a clear error instead of hitting the API.

**Extra**: Tests were added to lock in the payload shape (especially htmlContent with blocks: []). Serialization helpers for workflow responses were moved into a small shared module so workflow-steps no longer imports the main workflows module, which removed a circular dependency that showed up when loading those modules in isolation (e.g. in tests).