### PR TITLE
fix: condition schema definition

### DIFF
--- a/.changeset/fix-condition-variable-field.md
+++ b/.changeset/fix-condition-variable-field.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/agent-toolkit": patch
+---
+
+fix: rename condition schema field from `argument` to `variable` to match Knock API

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knocklabs/agent-toolkit",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knocklabs/agent-toolkit",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@knocklabs/mgmt": "^0.2.0",

--- a/src/lib/tools/__tests__/shared.test.ts
+++ b/src/lib/tools/__tests__/shared.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+
+import { conditionSchema } from "../shared.js";
+
+describe("conditionSchema", () => {
+  it("accepts a condition with argument when operator requires it", () => {
+    const result = conditionSchema.safeParse({
+      operator: "equal_to",
+      variable: "recipient.email",
+      argument: "john@example.com",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a condition missing argument when operator requires it", () => {
+    const result = conditionSchema.safeParse({
+      operator: "equal_to",
+      variable: "recipient.email",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a condition with argument when operator forbids it", () => {
+    const result = conditionSchema.safeParse({
+      operator: "not_empty",
+      variable: "recipient.id",
+      argument: "should-not-be-here",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a no-argument operator without argument", () => {
+    const result = conditionSchema.safeParse({
+      operator: "not_empty",
+      variable: "recipient.id",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/tools/guides.ts
+++ b/src/lib/tools/guides.ts
@@ -159,7 +159,7 @@ const createOrUpdateGuide = KnockTool({
 
   \`\`\`json
   [
-    { "operator": "equal_to", "value": "john.doe@example.com", "argument": "recipient.email" }
+    { "operator": "equal_to", "argument": "john.doe@example.com", "variable": "recipient.email" }
   ]
   \`\`\`
 

--- a/src/lib/tools/shared.ts
+++ b/src/lib/tools/shared.ts
@@ -11,6 +11,14 @@ const recipientSchema = z
     "A recipient can be a user ID or a reference to an object in a collection."
   );
 
+const noArgumentOperators = [
+  "empty",
+  "not_empty",
+  "exists",
+  "not_exists",
+  "is_timestamp",
+] as const;
+
 const conditionSchema = z
   .object({
     operator: z
@@ -24,17 +32,36 @@ const conditionSchema = z
         "contains",
         "not_contains",
         "contains_all",
-        "empty",
-        "not_empty",
+        "not_contains_all",
+        ...noArgumentOperators,
       ])
       .describe("(string): The operator to apply to the argument."),
-    value: z.any().describe("(any): The value of the condition."),
+    variable: z.string().describe("(string): The variable of the condition."),
     argument: z
       .string()
       .optional()
       .describe(
-        "(string): The argument of the condition. Can be empty when using empty or not_empty operators."
+        `(string): The argument of the condition. Required unless operator is ${noArgumentOperators.join(", ")}.`
       ),
+  })
+  .superRefine((data, ctx) => {
+    const operatorRequiresNoArgument = (
+      noArgumentOperators as readonly string[]
+    ).includes(data.operator);
+
+    if (operatorRequiresNoArgument && data.argument) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["argument"],
+        message: `argument must be empty when operator is ${data.operator}`,
+      });
+    } else if (!operatorRequiresNoArgument && !data.argument) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["argument"],
+        message: `argument is required when operator is ${data.operator}`,
+      });
+    }
   })
   .describe("(object): A condition.");
 


### PR DESCRIPTION
Fixes the following error when creating a guide (https://knocklabs.slack.com/archives/C07V5PE32MQ/p1776181587164739)

```
{"message":"An error occurred with the call to the Knock API: 422 One or more parameters supplied were invalid","error":{"status":422,"headers":{},"error":{"code":"invalid_params","errors":[{"field":"target_property_conditions.all","message":"­`variable­` can't be blank in a condition: {\"operator\":\"not_empty\"}"}],"message":"One or more parameters supplied were invalid","status":422,"type":"invalid_request_error"}}}
```