### PR TITLE
fix: update `upsert_guide` tool schema to match the latest MAPI

### DIFF
--- a/.changeset/fix-guide-upsert-schema.md
+++ b/.changeset/fix-guide-upsert-schema.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/agent-toolkit": patch
+---
+
+fix: update `upsert_guide` tool schema to match Knock API — rename `activationLocationRules` to `activationUrlPatterns`, support matching on query string via `search`, and tighten field validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
-        "@knocklabs/mgmt": "^0.2.0",
+        "@knocklabs/mgmt": "^0.24.0",
         "@knocklabs/node": "^1.10.3",
         "@modelcontextprotocol/sdk": "^1.7.0",
         "@sentry/node": "^10.5.0",
@@ -2226,9 +2226,9 @@
       "peer": true
     },
     "node_modules/@knocklabs/mgmt": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@knocklabs/mgmt/-/mgmt-0.2.0.tgz",
-      "integrity": "sha512-VHkXfYbG8GdbUriAuQ4YnpB5N67LwfFTz0OpXtRRzRx+IlL+7weH0yZA6Mg7msjhqbVnkxhBe1dtyaln6VN3+w=="
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@knocklabs/mgmt/-/mgmt-0.24.0.tgz",
+      "integrity": "sha512-PZTWZ+49sB+XP7fnHQQ9HqJosH5zDuVCJoTXNyAgL+q3ZIxUWcsqUZehwvbHhSE+4/1g/mIehIijP4EnU+DPXg=="
     },
     "node_modules/@knocklabs/node": {
       "version": "1.10.3",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "dist"
   ],
   "dependencies": {
-    "@knocklabs/mgmt": "^0.2.0",
+    "@knocklabs/mgmt": "^0.24.0",
     "@knocklabs/node": "^1.10.3",
     "@modelcontextprotocol/sdk": "^1.7.0",
     "@sentry/node": "^10.5.0",

--- a/src/lib/tools/__tests__/guides.test.ts
+++ b/src/lib/tools/__tests__/guides.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { KnockClient } from "../../knock-client.js";
+import { guides } from "../guides.js";
+
+const mockMessageType = {
+  key: "banner",
+  semver: "1.0.0",
+  variants: [{ key: "default" }],
+};
+
+const mockGuide = {
+  key: "welcome",
+  name: "Welcome",
+  description: null,
+  type: "default",
+  active: true,
+  steps: [],
+};
+
+describe("upsert_guide parameters schema", () => {
+  const schema = guides.createOrUpdateGuide.parameters!;
+
+  const validInput = {
+    guideKey: "welcome",
+    name: "Welcome",
+    step: {
+      schemaKey: "banner",
+      schemaContent: { title: "hi" },
+    },
+  };
+
+  describe("guideKey", () => {
+    it("rejects a key shorter than 3 characters", () => {
+      const result = schema.safeParse({ ...validInput, guideKey: "ab" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a key that violates the regex pattern", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        guideKey: "Welcome Guide!",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts keys containing hyphens and underscores", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        guideKey: "welcome-guide_1",
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("normalizes uppercase to lowercase", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        guideKey: "Welcome_Guide",
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.guideKey).toBe("welcome_guide");
+      }
+    });
+  });
+
+  describe("name", () => {
+    it("rejects an empty name", () => {
+      const result = schema.safeParse({ ...validInput, name: "" });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a name longer than 255 characters", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        name: "a".repeat(256),
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("description", () => {
+    it("rejects a description longer than 280 characters", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        description: "a".repeat(281),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts an omitted description", () => {
+      const result = schema.safeParse(validInput);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("channelKey", () => {
+    it("defaults to knock-guide when omitted", () => {
+      const result = schema.safeParse(validInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.channelKey).toBe("knock-guide");
+      }
+    });
+  });
+
+  describe("step", () => {
+    it("rejects an empty schemaKey", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        step: { ...validInput.step, schemaKey: "" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("applies defaults for ref and schemaVariantKey", () => {
+      const result = schema.safeParse(validInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.step.ref).toBe("step_1");
+        expect(result.data.step.schemaVariantKey).toBe("default");
+      }
+    });
+  });
+
+  describe("activationUrlPatterns", () => {
+    it("rejects a rule with neither pathname nor search", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        activationUrlPatterns: [{ directive: "allow" }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts a rule with only pathname", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        activationUrlPatterns: [{ directive: "allow", pathname: "/dashboard" }],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a rule with only search", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        activationUrlPatterns: [
+          { directive: "allow", search: "*tour=welcome*" },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a rule with both pathname and search", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        activationUrlPatterns: [
+          {
+            directive: "allow",
+            pathname: "/dashboard",
+            search: "*tab=overview*",
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects an invalid directive value", () => {
+      const result = schema.safeParse({
+        ...validInput,
+        activationUrlPatterns: [{ directive: "deny", pathname: "/admin" }],
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("upsert_guide execute", () => {
+  const config = { serviceToken: "test" };
+
+  let upsertMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    upsertMock = vi.fn().mockResolvedValue({ guide: mockGuide });
+  });
+
+  function makeClient(): KnockClient {
+    return {
+      messageTypes: {
+        retrieve: vi.fn().mockResolvedValue(mockMessageType),
+      },
+      guides: {
+        upsert: upsertMock,
+      },
+    } as unknown as KnockClient;
+  }
+
+  function getUpsertedGuide() {
+    const [, params] = upsertMock.mock.calls[0] as [
+      string,
+      { guide: Record<string, unknown> },
+    ];
+    return params.guide;
+  }
+
+  it("omits optional fields when not provided", async () => {
+    const run = guides.createOrUpdateGuide.bindExecute(makeClient(), config);
+
+    await run({
+      guideKey: "welcome",
+      name: "Welcome",
+      channelKey: "knock-guide",
+      step: {
+        ref: "step_1",
+        schemaKey: "banner",
+        schemaVariantKey: "default",
+        schemaContent: { title: "hi" },
+      },
+    });
+
+    const guide = getUpsertedGuide();
+    expect(guide).not.toHaveProperty("description");
+    expect(guide).not.toHaveProperty("target_property_conditions");
+    expect(guide).not.toHaveProperty("activation_url_patterns");
+  });
+
+  it("sends activation_url_patterns with the provided pattern", async () => {
+    const run = guides.createOrUpdateGuide.bindExecute(makeClient(), config);
+
+    const patterns = [{ directive: "allow", pathname: "/dashboard" }];
+    await run({
+      guideKey: "welcome",
+      name: "Welcome",
+      channelKey: "knock-guide",
+      step: {
+        ref: "step_1",
+        schemaKey: "banner",
+        schemaVariantKey: "default",
+        schemaContent: { title: "hi" },
+      },
+      activationUrlPatterns: patterns,
+    });
+
+    const guide = getUpsertedGuide();
+    expect(guide).toHaveProperty("activation_url_patterns", patterns);
+  });
+});

--- a/src/lib/tools/guides.ts
+++ b/src/lib/tools/guides.ts
@@ -232,7 +232,7 @@ const createOrUpdateGuide = KnockTool({
       ),
     step: z
       .object({
-        name: z.string().describe("(string): The name of the step.").optional(),
+        name: z.string().optional().describe("(string): The name of the step."),
         ref: z
           .string()
           .describe("(string): The unique identifier of the step.")

--- a/src/lib/tools/guides.ts
+++ b/src/lib/tools/guides.ts
@@ -204,9 +204,10 @@ const createOrUpdateGuide = KnockTool({
       .string()
       .min(3)
       .max(255)
-      .regex(/^[a-z0-9_-]+$/)
+      .regex(/^[a-zA-Z0-9_-]+$/)
+      .transform((val) => val.toLowerCase())
       .describe(
-        "(string): The key of the guide to upsert. Must be at minimum 3 characters and at maximum 255 characters in length. Must be in the format of ^[a-z0-9_-]+$."
+        "(string): The key of the guide to upsert. Must be at minimum 3 characters and at maximum 255 characters in length. Must be in the format of ^[a-zA-Z0-9_-]+$. Uppercase characters will be normalized to lowercase."
       ),
     name: z
       .string()

--- a/src/lib/tools/guides.ts
+++ b/src/lib/tools/guides.ts
@@ -1,3 +1,4 @@
+import KnockMgmt from "@knocklabs/mgmt";
 import { Guide } from "@knocklabs/mgmt/resources.js";
 import { z } from "zod";
 
@@ -123,7 +124,7 @@ const createOrUpdateGuide = KnockTool({
   When working with guide steps, you must use a \`schemaKey\` and \`schemaVariantKey\` to reference the message type schema that the step's content conforms to. You can use the \`list_message_types\` tool to get a list of available message types and the available variants for that message type.
 
   You **must** supply a \`schemaContent\` that sets the content for each of the fields in the \`fields\` object inside of the message type schema variant you select.
-  
+
   For example, if you have a message type schema with a \`fields\` object that looks like this:
 
   \`\`\`json
@@ -163,16 +164,32 @@ const createOrUpdateGuide = KnockTool({
   ]
   \`\`\`
 
-  ### Activation location rules
+  ### Activation URL patterns
 
-  You can supply a list of activation location rules to describe where in your application the guide should be shown. Each activation rule is a directive that describes whether the guide should be shown or hidden based on the pathname of the page.
+  You can supply a list of activation URL patterns to describe where in your application the guide should be shown. Each activation pattern is a directive that describes whether the guide should be shown or hidden based on the pathname and/or search (query string) of the page. Each pattern must include at least one of \`pathname\` or \`search\` (both may be provided together).
 
-  For example, if you want to show the guide on all pages except for the \`admin\` path, you would supply the following activation location rules:
+  For example, if you want to show the guide on all pages except for the \`admin\` path, you would supply the following activation URL patterns:
 
   \`\`\`json
   [
     { "directive": "allow", "pathname": "*" },
     { "directive": "block", "pathname": "/admin" }
+  ]
+  \`\`\`
+
+  You can also match on the query string using \`search\`. For example, to show the guide only when the URL has a \`tour=welcome\` query parameter:
+
+  \`\`\`json
+  [
+    { "directive": "allow", "search": "*tour=welcome*" }
+  ]
+  \`\`\`
+
+  You can combine \`pathname\` and \`search\` in a single rule to match both. For example, to show the guide only on \`/dashboard\` when \`tab=overview\` is present:
+
+  \`\`\`json
+  [
+    { "directive": "allow", "pathname": "/dashboard", "search": "*tab=overview*" }
   ]
   \`\`\`
   `,
@@ -185,11 +202,16 @@ const createOrUpdateGuide = KnockTool({
       ),
     guideKey: z
       .string()
+      .min(3)
+      .max(255)
+      .regex(/^[a-z0-9_-]+$/)
       .describe(
         "(string): The key of the guide to upsert. Must be at minimum 3 characters and at maximum 255 characters in length. Must be in the format of ^[a-z0-9_-]+$."
       ),
     name: z
       .string()
+      .min(1)
+      .max(255)
       .describe(
         "(string): A name for the guide. Must be at maximum 255 characters in length."
       ),
@@ -202,26 +224,24 @@ const createOrUpdateGuide = KnockTool({
       .default("knock-guide"),
     description: z
       .string()
+      .max(280)
       .optional()
       .describe(
         "(string): An arbitrary string attached to a guide object. Maximum of 280 characters allowed."
       ),
     step: z
       .object({
-        name: z
-          .string()
-          .describe("(string): The name of the step.")
-          .optional()
-          .default("Default"),
+        name: z.string().describe("(string): The name of the step.").optional(),
         ref: z
           .string()
           .describe("(string): The unique identifier of the step.")
           .optional()
-          .default("default"),
+          .default("step_1"),
         schemaKey: z
           .string()
+          .min(1)
           .describe(
-            "(string): The key of the schema that the step's content conforms to."
+            "(string): The key of the message type to use for the step's content. Note, Knock provides out-of-the-box message types: `banner`, `card`, and `modal` in addition to any user created ones."
           ),
         schemaVariantKey: z
           .string()
@@ -239,26 +259,45 @@ const createOrUpdateGuide = KnockTool({
       .describe("(object): The guide step to upsert."),
     targetPropertyConditions: z
       .array(conditionSchema)
+      .optional()
       .describe(
-        "(array): A list of property conditions that describe the target audience for the guide. Conditions are joined as AND operations."
+        "(array): A list of target conditions to be met for the guide to be shown to a user. Conditions are joined as AND operations."
       ),
-    activationLocationRules: z
+    activationUrlPatterns: z
       .array(
-        z.object({
-          directive: z
-            .enum(["allow", "block"])
-            .describe(
-              "(string): The directive to apply to the activation location rule (allow or block)."
-            ),
-          pathname: z
-            .string()
-            .describe(
-              "(string): The pathname to target. Should correspond to a URI in your application."
-            ),
-        })
+        z
+          .object({
+            directive: z
+              .enum(["allow", "block"])
+              .describe(
+                "(string): The directive to apply to the activation URL rule (allow or block)."
+              ),
+            pathname: z
+              .string()
+              .min(1)
+              .optional()
+              .describe(
+                "(string): The URL pathname pattern to match against. Must be a valid URI path."
+              ),
+            search: z
+              .string()
+              .min(1)
+              .optional()
+              .describe(
+                "(string): The URL query string pattern to match against (without the leading '?'). Supports URLPattern API syntax."
+              ),
+          })
+          .refine(
+            (data) => data.pathname !== undefined || data.search !== undefined,
+            {
+              message:
+                "At least one of `pathname` or `search` must be provided.",
+            }
+          )
       )
+      .optional()
       .describe(
-        "(array): A list of activation location rules that describe where in your application the guide should be shown."
+        "(array): A list of activation URL rules that describe where in your application the guide should be shown."
       ),
   }),
   execute: (knockClient, config) => async (params) => {
@@ -269,38 +308,52 @@ const createOrUpdateGuide = KnockTool({
         environment: params.environment ?? config.environment ?? "development",
       }
     );
+    if (!messageType) {
+      throw new Error(`Message type ${params.step.schemaKey} not found`);
+    }
 
     // Ensure that the schema variant exists
     const schemaVariant = messageType.variants.find(
       (variant) => variant.key === params.step.schemaVariantKey
     );
-
     if (!schemaVariant) {
       throw new Error(
         `Schema variant ${params.step.schemaVariantKey} not found in message type ${messageType.key}`
       );
     }
 
+    // Build the guide data based on the provided params.
+    const guideData: KnockMgmt.GuideUpsertParams.Guide = {
+      name: params.name,
+      channel_key: params.channelKey,
+      steps: [
+        {
+          ref: params.step.ref,
+          schema_key: messageType.key,
+          schema_semver: messageType.semver,
+          schema_variant_key: schemaVariant.key,
+          values: params.step.schemaContent,
+        },
+      ],
+    };
+
+    if (params.description) {
+      guideData.description = params.description;
+    }
+
+    if (params.targetPropertyConditions) {
+      guideData.target_property_conditions = {
+        all: params.targetPropertyConditions,
+      };
+    }
+
+    if (params.activationUrlPatterns) {
+      guideData.activation_url_patterns = params.activationUrlPatterns;
+    }
+
     const result = await knockClient.guides.upsert(params.guideKey, {
       environment: params.environment ?? config.environment ?? "development",
-      guide: {
-        name: params.name,
-        description: params.description,
-        channel_key: params.channelKey ?? "knock-guide",
-        steps: [
-          {
-            ref: params.step.ref ?? "default",
-            schema_key: messageType.key,
-            schema_semver: messageType.semver,
-            schema_variant_key: schemaVariant.key,
-            values: params.step.schemaContent,
-          },
-        ],
-        target_property_conditions: {
-          all: params.targetPropertyConditions,
-        },
-        activation_location_rules: params.activationLocationRules,
-      },
+      guide: guideData,
     });
 
     return serializeGuide(result.guide);


### PR DESCRIPTION
Tested it locally:

<img width="2556" height="2194" alt="CleanShot 2026-04-16 at 17 00 45@2x" src="https://github.com/user-attachments/assets/1aeb2fa3-0e46-46c1-89bc-0e76607e36ec" />
