### PR TITLE
fix: call user preference SDK methods with a positional preference set id

### DIFF
--- a/.changeset/fix-user-preferences-sdk-signature.md
+++ b/.changeset/fix-user-preferences-sdk-signature.md
@@ -1,0 +1,5 @@
+---
+"@knocklabs/agent-toolkit": patch
+---
+
+Fix `get_user_preferences` and `set_user_preferences` calling the Knock SDK with its pre-1.x argument shape. The preference set id was passed inside an options object, which the current SDK stringifies into the request path as `[object Object]`; the write call also sent the preferences body in the id slot with no body at all. Both tools now pass the preference set id as the positional string argument.

--- a/src/lib/tools/__tests__/users.test.ts
+++ b/src/lib/tools/__tests__/users.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { KnockClient } from "../../knock-client.js";
+import { users } from "../users.js";
+
+describe("user preference tools", () => {
+  const config = { serviceToken: "test", userId: "config_user" };
+
+  let getPreferencesMock: ReturnType<typeof vi.fn>;
+  let setPreferencesMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    getPreferencesMock = vi.fn().mockResolvedValue({
+      workflows: { existing: { channel_types: { email: true } } },
+      categories: {},
+      channel_types: {},
+    });
+    setPreferencesMock = vi.fn().mockResolvedValue({});
+  });
+
+  function makeClient(): KnockClient {
+    return {
+      publicApi: vi.fn().mockResolvedValue({
+        users: {
+          getPreferences: getPreferencesMock,
+          setPreferences: setPreferencesMock,
+        },
+      }),
+    } as unknown as KnockClient;
+  }
+
+  describe("get_user_preferences", () => {
+    it("passes the preference set id as a positional string", async () => {
+      const run = users.getUserPreferences.bindExecute(makeClient(), config);
+
+      await run({ userId: "user_1", preferenceSetId: "my-tenant" });
+
+      expect(getPreferencesMock).toHaveBeenCalledWith("user_1", "my-tenant");
+    });
+
+    it("defaults the preference set id to `default`", async () => {
+      const run = users.getUserPreferences.bindExecute(makeClient(), config);
+
+      await run({ userId: "user_1" });
+
+      expect(getPreferencesMock).toHaveBeenCalledWith("user_1", "default");
+    });
+  });
+
+  describe("set_user_preferences", () => {
+    it("reads existing preferences with a positional preference set id", async () => {
+      const run = users.setUserPreferences.bindExecute(makeClient(), config);
+
+      await run({
+        userId: "user_1",
+        workflows: { welcome: { channel_types: { email: false } } },
+      });
+
+      expect(getPreferencesMock).toHaveBeenCalledWith("user_1", "default");
+    });
+
+    it("writes with the preference set id and the merged body as separate arguments", async () => {
+      const run = users.setUserPreferences.bindExecute(makeClient(), config);
+
+      await run({
+        userId: "user_1",
+        workflows: { welcome: { channel_types: { email: false } } },
+      });
+
+      expect(setPreferencesMock).toHaveBeenCalledWith(
+        "user_1",
+        "default",
+        expect.objectContaining({
+          workflows: expect.objectContaining({
+            existing: { channel_types: { email: true } },
+            welcome: { channel_types: { email: false } },
+          }),
+        })
+      );
+    });
+  });
+});

--- a/src/lib/tools/users.ts
+++ b/src/lib/tools/users.ts
@@ -129,9 +129,7 @@ const getUserPreferences = KnockTool({
 
     return await publicClient.users.getPreferences(
       params.userId ?? config.userId,
-      {
-        preferenceSet: params.preferenceSetId ?? "default",
-      }
+      params.preferenceSetId ?? "default"
     );
   },
 });
@@ -206,9 +204,7 @@ const setUserPreferences = KnockTool({
 
     const existingPreferences = await publicClient.users.getPreferences(
       params.userId ?? config.userId,
-      {
-        preferenceSet: "default",
-      }
+      "default"
     );
 
     const updatedPreferences = {
@@ -229,6 +225,7 @@ const setUserPreferences = KnockTool({
 
     return await publicClient.users.setPreferences(
       params.userId ?? config.userId,
+      "default",
       updatedPreferences
     );
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,13 @@
+import path from 'node:path';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
Fixes #51

## What was broken

The current `@knocklabs/node` SDK takes the preference set id as a positional string — `getPreferences(userID, id, query?)` / `setPreferences(userID, id, body)` — but both preference tools in `src/lib/tools/users.ts` still used the pre-1.x options-object shape:

- `get_user_preferences` passed `{ preferenceSet: … }` where the SDK expects the id string, so it was stringified into the request path as `[object Object]` and every call failed with *"Value of type Object is not a valid path parameter"*.
- `set_user_preferences` had the same broken read internally, and its write call passed the merged preferences object in the id slot with **no body at all**.

## What changed

- The three call sites now pass the preference set id positionally (`params.preferenceSetId ?? "default"` for the read tool, `"default"` for the read+write inside the set tool), with the body as the third argument on the write.
- Added `__tests__/users.test.ts` covering the argument shapes for both tools (all four tests fail against the previous code).
- Added the tsconfig `@` alias to `vitest.config.ts` — the new suite transitively imports `tools/index.ts` → `partials.ts`, which uses the `@/` import style, and vitest could not resolve it before.
- Changeset included (patch).

## Testing

- `vitest run`: 47/47 (43 existing + 4 new)
- `npm run lint` and `npm run build`: clean